### PR TITLE
fix: resolve macOS ABI3 build and workflow reusable issues

### DIFF
--- a/.github/workflows/build-abi3.yml
+++ b/.github/workflows/build-abi3.yml
@@ -86,28 +86,39 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           architecture: x64
-      
+
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Build ABI3 wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --features abi3
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      
+
+      - name: List built files
+        run: |
+          echo "Contents of dist directory:"
+          ls -la dist/
+          echo "Looking for wheel files:"
+          find dist -name "*.whl" -type f
+
       - name: Install built wheel
         if: matrix.target == 'x86_64'
         run: |
-          pip install pyrustor --find-links dist --force-reinstall
+          echo "Available wheel files:"
+          ls -la dist/*.whl || echo "No .whl files found"
+          pip install pyrustor --find-links dist --force-reinstall --no-deps
           python -c "import pyrustor; print('PyRustor imported successfully')"
-      
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Fixes reusable workflow permission issues and macOS ABI3 build failures.

Changes:
- Fixed workflow calls in release.yml
- Added Rust toolchain for macOS ABI3 builds  
- Enhanced debugging and wheel installation
- Improved error handling

This resolves the 'Unable to find reusable workflow' errors and macOS build failures.