### PR TITLE
fix: add missing psutil dependency for ABI3 wheel tests

### DIFF
--- a/.github/workflows/build-abi3.yml
+++ b/.github/workflows/build-abi3.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install pyrustor --find-links dist --force-reinstall
           python scripts/test_wheel_integrity.py
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov psutil
           python -m pytest tests/ -v --tb=short -m "not benchmark and not slow"
       
       - name: Upload wheels
@@ -75,7 +75,7 @@ jobs:
         run: |
           pip install pyrustor --find-links dist --force-reinstall
           python scripts/test_wheel_integrity.py
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov psutil
           python -m pytest tests/ -v --tb=short -m "not benchmark and not slow"
       
       - name: Upload wheels
@@ -119,7 +119,7 @@ jobs:
         run: |
           pip install pyrustor --find-links dist --force-reinstall
           python scripts/test_wheel_integrity.py
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov psutil
           python -m pytest tests/ -v --tb=short -m "not benchmark and not slow"
 
       - name: Upload wheels


### PR DESCRIPTION
## 🐛 Problem

The ABI3 wheel builds are failing with `ModuleNotFoundError: No module named 'psutil'` during test execution.

## 🔍 Root Cause

The benchmark tests in `tests/test_benchmarks.py` use `psutil.Process()` to monitor memory usage, but the ABI3 build workflow only installs `pytest pytest-cov` without the required `psutil` dependency.

## ✅ Solution

Add `psutil` to the pip install commands in all ABI3 build steps:
- Linux ABI3 builds
- Windows ABI3 builds  
- macOS ABI3 builds

## 📋 Changes

- Updated `.github/workflows/build-abi3.yml`
- Changed `pip install pytest pytest-cov` to `pip install pytest pytest-cov psutil`
- Applied to all three platform builds (Linux, Windows, macOS)

## 🧪 Testing

This fix ensures that:
- ✅ Benchmark tests can run without import errors
- ✅ Memory usage monitoring works correctly
- ✅ ABI3 wheels are properly tested before upload
- ✅ Release-please triggered builds will succeed

## 📚 Context

`psutil>=5.9.0` is already defined in `pyproject.toml` under the `test` dependency group, but ABI3 builds use minimal pip installs rather than uv dependency groups.