### PR TITLE
fix: resolve CI test dependencies and version sync consistency

### DIFF
--- a/.github/actions/sync-versions/action.yml
+++ b/.github/actions/sync-versions/action.yml
@@ -41,9 +41,9 @@ runs:
           grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/'
         }
         
-        # Function to extract version from pyproject.toml
+        # Function to extract version from Python package __init__.py
         get_python_version() {
-          grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/'
+          grep '__version__ = ' python/pyrustor/__init__.py | head -1 | sed 's/__version__ = "\(.*\)"/\1/'
         }
         
         # Function to extract version from package.json (if exists)
@@ -73,7 +73,7 @@ runs:
         
         echo "Current versions:"
         echo "  Cargo.toml: $CARGO_VERSION"
-        echo "  pyproject.toml: $PYTHON_VERSION"
+        echo "  Python package: $PYTHON_VERSION"
         
         # Check if package.json exists
         if [ -f "package.json" ]; then
@@ -89,7 +89,7 @@ runs:
         fi
         
         if [ "$PYTHON_VERSION" != "$TARGET_VERSION" ]; then
-          echo "❌ pyproject.toml version ($PYTHON_VERSION) != target ($TARGET_VERSION)"
+          echo "❌ Python package version ($PYTHON_VERSION) != target ($TARGET_VERSION)"
           NEEDS_SYNC=true
         fi
         
@@ -121,10 +121,10 @@ runs:
           echo "✅ Updated Cargo.toml: $CARGO_VERSION -> $TARGET_VERSION"
         fi
         
-        # Update pyproject.toml
+        # Update Python package __init__.py
         if [ "$PYTHON_VERSION" != "$TARGET_VERSION" ]; then
-          sed -i.bak "s/^version = \".*\"/version = \"$TARGET_VERSION\"/" pyproject.toml
-          echo "✅ Updated pyproject.toml: $PYTHON_VERSION -> $TARGET_VERSION"
+          sed -i.bak "s/__version__ = \".*\"/__version__ = \"$TARGET_VERSION\"/" python/pyrustor/__init__.py
+          echo "✅ Updated Python package: $PYTHON_VERSION -> $TARGET_VERSION"
         fi
         
         # Update package.json if it exists
@@ -147,11 +147,11 @@ runs:
         echo "🔍 Verifying version synchronization..."
         
         CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-        PYTHON_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-        
+        PYTHON_VERSION=$(grep '__version__ = ' python/pyrustor/__init__.py | head -1 | sed 's/__version__ = "\(.*\)"/\1/')
+
         echo "Final versions:"
         echo "  Cargo.toml: $CARGO_VERSION"
-        echo "  pyproject.toml: $PYTHON_VERSION"
+        echo "  Python package: $PYTHON_VERSION"
         
         if [ -f "package.json" ]; then
           PACKAGE_VERSION=$(grep '"version":' package.json | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -16,12 +16,12 @@ on:
     branches: [main]
     paths:
       - 'Cargo.toml'
-      - 'pyproject.toml'
+      - 'python/pyrustor/__init__.py'
       - 'package.json'
   pull_request:
     paths:
       - 'Cargo.toml'
-      - 'pyproject.toml'
+      - 'python/pyrustor/__init__.py'
       - 'package.json'
 
 permissions:
@@ -100,7 +100,7 @@ jobs:
 
           Synchronized version numbers across:
           - Cargo.toml
-          - pyproject.toml
+          - python/pyrustor/__init__.py
           - package.json (if exists)
           
           All files now use version ${{ steps.sync.outputs.current-version }}"
@@ -126,7 +126,7 @@ jobs:
             
             ### Files Updated:
             - ✅ Cargo.toml
-            - ✅ pyproject.toml
+            - ✅ python/pyrustor/__init__.py
             - ✅ package.json (if exists)
             
             ### Changes Made:

--- a/justfile
+++ b/justfile
@@ -100,7 +100,7 @@ check: format lint test
 # CI-specific commands
 ci-install:
     @echo "📦 Installing CI dependencies..."
-    uv sync --group dev
+    uv sync --group dev --group test
 
 ci-build:
     @echo "🔧 Building extension for CI..."

--- a/python/pyrustor/__init__.py
+++ b/python/pyrustor/__init__.py
@@ -26,7 +26,7 @@ from ._pyrustor import (
     CodeGenerator,
 )
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     "Parser",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,11 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "generic",
+          "path": "python/pyrustor/__init__.py",
+          "glob": true
         }
       ]
     }


### PR DESCRIPTION
## 🐛 Problems Fixed

### 1. CI Test Dependencies Issue
CI tests were failing with `ModuleNotFoundError: No module named 'psutil'` because the `ci-install` command only installed the `dev` dependency group, but `psutil` is defined in the `test` dependency group.

### 2. Version Sync Consistency Issue  
PR and release stages had inconsistent versions due to improper handling of Python package versioning in release-please and version sync workflows.

## 🔍 Root Causes

1. **CI Dependencies**: `justfile ci-install` only ran `uv sync --group dev`, missing `--group test`
2. **Version Management**: release-please and sync scripts had inconsistent version file handling
3. **Python Package Version**: Was out of sync with release-please manifest (0.1.4 vs 0.1.5)

## ✅ Solutions

### CI Test Dependencies
- Updated `justfile ci-install`: `uv sync --group dev --group test`
- Now includes all test dependencies including `psutil>=5.9.0`

### Version Sync Consistency
- Updated release-please config to handle Python package `__init__.py`
- Modified version sync scripts to work with `python/pyrustor/__init__.py`
- Synchronized Python package version to 0.1.5
- Fixed workflow paths and descriptions

## 📋 Changes

- **justfile**: Added `--group test` to `ci-install` command
- **.github/actions/sync-versions/action.yml**: Handle `__init__.py` versions correctly
- **.github/workflows/version-sync.yml**: Updated paths and descriptions
- **python/pyrustor/__init__.py**: Synced version to 0.1.5
- **release-please-config.json**: Added Python package to extra-files

## 🧪 Testing

Verified locally:
- ✅ `uv run python -c "import psutil; print('success')"`
- ✅ `uv run python -c "import tests.test_benchmarks"`
- ✅ `uv run python scripts/sync_versions.py --check-only`
- ✅ All versions synchronized at 0.1.5

## 📊 Impact

- ✅ CI Python tests can now import psutil successfully
- ✅ Benchmark tests will run without ModuleNotFoundError
- ✅ All test dependencies are available in CI environment
- ✅ All versions synchronized across all files
- ✅ release-please will correctly update Python package versions
- ✅ Version sync workflows will work correctly
- ✅ PR and release stages will have consistent versions

## 🔗 Related

- Builds on PR #22 (ABI3 psutil fix)
- Resolves version inconsistency issues
- Ensures CI reliability for all test types

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author