### PR TITLE
fix: resolve GitHub release action tag reference issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,17 +97,18 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [pypi-publish]
+    needs: [release-please, pypi-publish]
+    if: ${{ needs.release-please.outputs.release_created }}
     permissions:
       contents: write # Required for creating releases
       actions: read # Required for downloading artifacts
       attestations: write # Required for artifact attestation
-    
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Generate changelog
         id: changelog
         uses: jaywcjlove/changelog-generator@main
@@ -118,31 +119,36 @@ jobs:
           template: |
             ## Bugs
             {{fix}}
-            
+
             ## Feature
             {{feat}}
-            
+
             ## Improve
             {{refactor,perf,clean}}
-            
+
             ## Misc
             {{chore,style,ci}}
             🔧 Nothing change}}
-            
+
             ## Unknown
             {{__unknown__}}
-      
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-artifacts
           merge-multiple: true
-      
-      - uses: ncipollo/release-action@v1
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
         with:
           artifacts: "release-artifacts/*"
           token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.release-please.outputs.tag_name }}
+          name: ${{ needs.release-please.outputs.tag_name }}
           body: |
             Comparing Changes: ${{ steps.changelog.outputs.compareurl }}
-            
+
             ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Problem

The GitHub Actions workflow for creating releases was failing with the error:
```
Error undefined: No tag found in ref or input!
```

This error occurred in the `ncipollo/release-action@v1` step because it couldn't find the tag reference.

## Solution

This PR fixes the issue by:

1. **Adding explicit tag reference**: Pass `tag: ${{ needs.release-please.outputs.tag_name }}` to the release action
2. **Adding release name**: Pass `name: ${{ needs.release-please.outputs.tag_name }}` for consistent naming
3. **Adding proper dependency**: Include `release-please` in the `needs` array to ensure tag_name is available
4. **Adding conditional execution**: Only run when `release_created` is true to avoid unnecessary runs
5. **Adding explicit release settings**: Set `draft: false` and `prerelease: false` for clarity

## Changes

- Modified `.github/workflows/release.yml`:
  - Updated `github-release` job dependencies
  - Added conditional execution based on release creation
  - Added explicit tag and name parameters to `ncipollo/release-action`
  - Added explicit draft and prerelease settings

## Testing

This change ensures that:
- The release action only runs when a release is actually created by release-please
- The tag information is properly passed from the release-please job
- GitHub releases are created with the correct tag and name

## Related Issues

Fixes the GitHub Actions failure shown in the workflow runs where the release creation step was failing due to missing tag reference.